### PR TITLE
Fix screenName parameter in ScreenHit class

### DIFF
--- a/hits.js
+++ b/hits.js
@@ -46,7 +46,7 @@ export class PageHit extends Hit {
 
 export class ScreenHit extends Hit {
     constructor(screenName) {
-        super({ dp: screenName, t: 'screenview' });
+        super({ cd: screenName, t: 'screenview' });
     }
 }
 


### PR DESCRIPTION
Changed property dp to cd to match Google Analytics screen hit request reference

See https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide

*Proper Request*

``
v=1                         // Version.
&tid=UA-XXXXX-Y             // Tracking ID / Property ID.
&cid=555                    // Anonymous Client ID.

&t=screenview               // Screenview hit type.
&an=funTimes                // App name.
&av=1.5.0                   // App version.
&aid=com.foo.App            // App Id.
&aiid=com.android.vending   // App Installer Id.
&cd=Home                    // Screen name / content description.
``