### PR TITLE
add method addParameter(name, value) to allow adding parameters after initialisation

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -46,6 +46,10 @@ export default class Analytics {
             .then(() => this.send(event));
     }
 
+    addParameter(name, value){
+        this.parameters[name] = value;
+    }
+
     addCustomDimension(index, value){
         this.customDimensions[index] = value;
     }


### PR DESCRIPTION
Sometimes it's required to add parameters after GA initialisation.
For example, I'd like to init GA at the app load but to specify UID after login.
At the moment all parameters need to be supplied at the initialisation.
This small change will allow adding parameters later on.