### PR TITLE
Updates import of Expo Constants for SDK33 compatibility

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,5 +1,5 @@
 import { Platform, Dimensions } from 'react-native';
-import { Constants } from 'expo';
+import Constants from 'expo-constants';
 
 import { ScreenHit, PageHit, Event, Serializable } from './hits';
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/ryanvanderpol/expo-analytics#readme",
   "dependencies": {
+    "expo-constants": "^5.0.1",
   },
   "devDependencies": {
     "expo": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/ryanvanderpol/expo-analytics#readme",
   "dependencies": {
-    "expo-constants": "^5.0.1",
+    "expo-constants": "^5.0.1"
   },
   "devDependencies": {
     "expo": "^20.0.0",


### PR DESCRIPTION
Hi there,

Expo v33 has deprecated the use of imports like this from the 'expo' package. https://blog.expo.io/expo-sdk-v33-0-0-is-now-available-52d1c99dfe4c#b331

e.g. `import { Constants } from 'expo'`

A lot of noise gets generated because of this now in the terminal.

This 1 line change is all that's required for v33 compatibility, although it would cause an issue for anyone on expo < v33 so perhaps a version bump is needed :)