### PR TITLE
Adding ecommerce tracking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,49 @@ import { Analytics } from 'expo-analytics';
 const analytics = new Analytics('UA-XXXXXX-Y', { uid: '999', dr: 'github.com', cn: 'get_more_views' });
 ```
 
+##### Ecommerce tracking 
+###### Transaction hit type
+You can also send purchase by constructing a new `Transaction` instance and passing it to the `transaction` function.  Transaction have five parameters. 
+
+* id (Required, string)
+* affiliation (Optional, string)
+* revenue (Optional, currency, but recommended)
+* shipping (Optional, currency)
+* tax (Optional, currency)
+
+These parameters are passed to the `Transaction` constructor in that order.
+
+```
+import { Analytics, Transaction } from 'expo-analytics';
+
+const analytics = new Analytics('UA-XXXXXX-Y');
+
+ analytics.hit(new Transaction('1235', 'Store', 38.43, 1.29, 5))
+  .then(() => console.log("success"))
+  .catch(e => console.log(e.message));
+```
+
+###### Item hit type
+You can also send along the purchase the products that were purchased in the transaction, constructing a new `AddItem` instance and passing it to the `AddItem` function. 'AddItem' have six parameters. 
+
+* id (The transaction id, Required, string)
+* name (Required, string)
+* price (Optional, currency, but recommended)
+* quantity (Optional, integer)
+* sku (Optional, string, but recommended)
+* category (Optional, string, but recommended)
+
+These parameters are passed to the `AddItem` constructor in that order.
+
+```
+import { Analytics, AddItem } from 'expo-analytics';
+
+const analytics = new Analytics('UA-XXXXXX-Y');
+
+ analytics.hit(new AddItem('1235', 'T-SHIRT', 11.99, 1, 'DD44', 'Clothes'))
+  .then(() => console.log("success"))
+  .catch(e => console.log(e.message));
+```
 
 ## Debugging
 

--- a/analytics.js
+++ b/analytics.js
@@ -74,6 +74,13 @@ export default class Analytics {
         * &sr= screen resolution
         * &cd{n}= custom dimensions
         * &z= cache buster (prevent browsers from caching GET requests -- should always be last)
+        * 
+        * Ecommerce track support (transaction)
+        * &ti= transaction The transaction ID. (e.g. 1234)
+        * &ta= The store or affiliation from which this transaction occurred (e.g. Acme Clothing).
+        * &tr= Specifies the total revenue or grand total associated with the transaction (e.g. 11.99). This value may include shipping, tax costs, or other adjustments to total revenue that you want to include as part of your revenue calculations.
+        * &tt= Specifies the total shipping cost of the transaction. (e.g. 5)
+        * 
         */
 
         const customDimensions = this.customDimensions.map((value, index) => `cd${index}=${value}`).join('&');

--- a/analytics.js
+++ b/analytics.js
@@ -81,6 +81,13 @@ export default class Analytics {
         * &tr= Specifies the total revenue or grand total associated with the transaction (e.g. 11.99). This value may include shipping, tax costs, or other adjustments to total revenue that you want to include as part of your revenue calculations.
         * &tt= Specifies the total shipping cost of the transaction. (e.g. 5)
         * 
+        * Ecommerce track support (addItem)
+        * &ti= transaction The transaction ID. (e.g. 1234)
+        * &in= The item name. (e.g. Fluffy Pink Bunnies)
+        * &ip= The individual, unit, price for each item. (e.g. 11.99)
+        * &iq= The number of units purchased in the transaction. If a non-integer value is passed into this field (e.g. 1.5), it will be rounded to the closest integer value.
+        * &ic= TSpecifies the SKU or item code. (e.g. SKU47)
+        * &iv= The category to which the item belongs (e.g. Party Toys)
         */
 
         const customDimensions = this.customDimensions.map((value, index) => `cd${index}=${value}`).join('&');

--- a/hits.js
+++ b/hits.js
@@ -61,3 +61,9 @@ export class Transaction extends Hit {
         super({ ti: id, ta: affiliation, tr: revenue, tt: tax, t: 'transaction' });
     }
 }
+
+export class AddItem extends Hit {
+    constructor(id, name, price, quantity, sku, category) {
+        super({ti: id, in: name, ip: price, iq: quantity, ic: sku, iv: category, t: 'item' });
+    }
+}

--- a/hits.js
+++ b/hits.js
@@ -55,3 +55,9 @@ export class Event extends Hit {
         super({ ec: category, ea: action, el: label, ev: value, t: 'event' });
     }
 }
+
+export class Transaction extends Hit {
+    constructor(id, affiliation, revenue, shipping, tax) {
+        super({ ti: id, ta: affiliation, tr: revenue, tt: tax, t: 'transaction' });
+    }
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { ScreenHit, PageHit, Event, Transaction } from './hits';
+import { ScreenHit, PageHit, Event, Transaction, AddItem } from './hits';
 import Analytics from './analytics';
 
-export { ScreenHit, PageHit, Event, Transaction, Analytics };
+export { ScreenHit, PageHit, Event, Transaction, AddItem, Analytics };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { ScreenHit, PageHit, Event } from './hits';
+import { ScreenHit, PageHit, Event, Transaction } from './hits';
 import Analytics from './analytics';
 
-export { ScreenHit, PageHit, Event, Analytics };
+export { ScreenHit, PageHit, Event, Transaction, Analytics };


### PR DESCRIPTION
Ecommerce tracking allows you to measure the number of transactions and revenue that your website generates. On a typical ecommerce site, once a user clicks the "purchase" button in the browser, the user's purchase information is sent to the web server, which carries out the transaction.
