### PR TITLE
User agent caching and static option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ analytics.hit(new PageHit('IsItWorking'))
   .catch(e => console.log(e.message));
 ``` 
 
+## More Options
+
+You might want to use your own static userAgent http header instead of the default WebView header.
+```
+const analytics = new Analytics('UA-XXXXXX-Y', null, { userAgent: 'Custom UserAgent' });
+```
+
+
 ## Release History
 
 * 1.0.11 Support for e-commerce tracking.  Thanks, @lucianfialhobp.

--- a/analytics.js
+++ b/analytics.js
@@ -7,6 +7,23 @@ const { width, height } = Dimensions.get('window');
 
 let defaultOptions = { debug: false };
 
+let webViewUserAgent = null;
+const getWebViewUserAgent = async (options) => {
+    return new Promise((resolve) => {
+        if (options.userAgent) {
+            webViewUserAgent = options.userAgent;
+            return resolve(options.userAgent);
+        }
+        if (webViewUserAgent) return resolve(webViewUserAgent);
+        Constants.getWebiewUserAgentAsync()
+          .then(userAgent => {
+              webViewUserAgent = userAgent;
+              resolve(userAgent);
+          })
+          .catch(() => resolve('unknown user agent'))
+    });
+}
+
 export default class Analytics {
     customDimensions = []
     customMetrics = []
@@ -16,7 +33,7 @@ export default class Analytics {
         this.options = options;
         this.clientId = Constants.deviceId;
 
-        this.promiseGetWebViewUserAgentAsync = Constants.getWebViewUserAgentAsync()
+        this.promiseGetWebViewUserAgentAsync = getWebViewUserAgent(options)
             .then(userAgent => {
                 this.userAgent = userAgent;
 


### PR DESCRIPTION
Caching the userAgent http header and give the ability to use custom userAgent http headers as an additional option. Background: The method `getWebbviewUserAgentAsync` can cause the error `The WKWWebView was invalidated` on iOS. This happened in our app >2k times. Caching the result of `getWebbviewUserAgentAsync` is fine because it is constant. (expo-constants)