### PR TITLE
FIX: only set user-agent header if not web

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -126,9 +126,10 @@ export default class Analytics {
 
         let options = {
             method: 'get',
-            headers: {
-                'User-Agent': this.userAgent
-            }
+        }
+
+        if (Platform.OS !== 'web') {
+            headers['User-Agent'] = this.userAgent;
         }
 
         if(this.options.debug){


### PR DESCRIPTION
We're using expo-analytics to build web (using expo-web) product. But after launching our product, we've seen significant drop for our users activities. It turns out that on Safari, requests to google analytics all being blocked by the browser. After some digging, `User-Agent` header will make this CORS request [not simple](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests). For safari, it will send an OPTION request to google analytics, google analytics will return 405 error and all the successive requests are blocked.

It's also reasonable for web not sending this header, it always send this header already

<img width="942" alt="截圖 2019-12-05 上午9 29 48" src="https://user-images.githubusercontent.com/78242/70195816-b67a4180-1741-11ea-9b5b-92831066694c.png">
