### PR TITLE
Added missing parameter screenTitle to the type definition

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -23,7 +23,7 @@ export interface Options {
 }
 
 export class PageHit {
-  constructor(pageName: string);
+  constructor(pageName: string, screenTitle: string);
 }
 
 export class ScreenHit {


### PR DESCRIPTION
Hi,
This commit adds the type definition for the screenTitle parameter, which was missing.