### PR TITLE
FIX: Added userAgent property to the Options interface

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -20,6 +20,7 @@ export interface MeasurementParamter {
 
 export interface Options {
   debug?: boolean;
+  userAgent?: string;
 }
 
 export class PageHit {


### PR DESCRIPTION
Options interface was missing the `userAgent` field